### PR TITLE
Show summer student meal section now and update its copy

### DIFF
--- a/src/components/customGreeting.vue
+++ b/src/components/customGreeting.vue
@@ -29,7 +29,7 @@ watch(
 
 const isSummer = computed(() => {
   const today = new Date();
-  const summerMealsBegin = new Date("2026-06-15");
+  const summerMealsBegin = new Date("2026-06-12");
   const summerMealsEnd = new Date("2026-08-21");
   return (summerMealsBegin < today) && (today < summerMealsEnd)
 });
@@ -208,8 +208,9 @@ const getCounts = () => {
         <div class="column small-cell-pad">
           <div v-html="$t('sections.studentMealSites.otherResources.p1')" />
           <ul>
+            <li v-html="$t('sections.studentMealSites.otherResources.li1')" />
             <li v-html="$t('sections.studentMealSites.otherResources.li2')" />
-            <li v-html="$t('sections.studentMealSites.otherResources.li4')" />
+            <li v-html="$t('sections.studentMealSites.otherResources.li3')" />
           </ul>
         </div>
       </div>

--- a/src/i18n/ar.js
+++ b/src/i18n/ar.js
@@ -161,16 +161,15 @@ export default{
         "p1": "يحصل جميع الطلاب في منطقة فيلادلفيا التعليمية على وجبة إفطار وغداء مجانية في المدرسة. لمعرفة المزيد، راجع صفحة خدمات الطعام في <a target='_blank' href='https://www.philasd.org/foodservices/'>المنطقة.</a>",
         "p2": "يمكن للشباب أيضًا الحصول على وجبات خفيفة أو وجبات في برامج <a target='_blank' href='https://www.phila.gov/ost/program-locator/'>Out of School Time.</a>"
       },
-      "eligibility": "الأطفال والشباب الذين تبلغ أعمارهم 18 عامًا أو أقل مؤهلون. لا يوجد معرف مطلوب.",
+      "eligibility": "جميع الأطفال والشباب الذين تبلغ أعمارهم 18 عامًا أو أقل مؤهلون. لا يوجد معرف مطلوب.",
       "pickupDetails": {
         "p1": "تقدم مواقع وجبات الطلاب وجبات جاهزة للأكل."
       },
       "otherResources": {
-        "p1": "للعثور على المزيد من الوجبات الصيفية للشباب:",
-        "li1": "اتصل بالخط الساخن للوجبات الصيفية على <a href='tel:215-770-4659'>(215) 770-4659</a>.",
-        "li2": "أرسل كلمة «فود» أو «كوميدا» إلى <a href='tel:914-342-7744'>914-342-7744</a>.",
-        "li3": "قم بزيارة <a target='_blank' href='http://www.phillysummermeals.org'>الموقع الإلكتروني www.phillysummermeals.org</a>.",
-        "li4": "قم بزيارة <a target='_blank' href='https://www.fns.usda.gov/summer/sitefinder'>www.fns.usda.gov/summer/sitefinder</a>."
+        "p1": "للعثور على المزيد من مواقع الوجبات الصيفية المجانية للشباب:",
+        "li1": "أرسل كلمة «SUMMER» إلى <a href='tel:914-342-7744'>914-342-7744</a>",
+        "li2": "قم بزيارة <a target='_blank' href='https://www.fns.usda.gov/summer/sitefinder'>www.fns.usda.gov/summer/sitefinder</a>",
+        "li3": "قم بزيارة <a target='_blank' href='https://www.phila.gov/summermeals'>www.phila.gov/summermeals</a>"
       },
       "subsections": {
         "PHA": {

--- a/src/i18n/ch.js
+++ b/src/i18n/ch.js
@@ -161,16 +161,15 @@ export default{
         "p1": "费城学区的所有学生在学校均可免费享用早餐和午餐。要了解更多信息，请参阅该<a target='_blank' href='https://www.philasd.org/foodservices/'>地区的餐饮服务页面。</a>",
         "p2": "年轻人还可以在课<a target='_blank' href='https://www.phila.gov/ost/program-locator/'>外活动中获得零食或餐食。</a>"
       },
-      "eligibility": "18 岁或以下的儿童和青少年符合资格。不需要身份证。",
+      "eligibility": "所有 18 岁或以下的儿童和青少年均符合资格。不需要身份证。",
       "pickupDetails": {
         "p1": "学生就餐网站提供即食餐点。"
       },
       "otherResources": {
-        "p1": "要为年轻人寻找更多夏季大餐，请执行以下操作：",
-        "li1": "拨打夏季膳食热线 <a href='tel:215-770-4659'>(215) 770-4659</a>。",
-        "li2": "发短信 “食物” 或 “COMIDA” 至 <a href='tel:914-342-7744'>9</a> 14-342-7744。",
-        "li3": "访问 <a target='_blank' href='http://www.phillysummermeals.org'>www.ph</a> illysummermeals.org。",
-        "li4": "访问 <a target='_blank' href='https://www.fns.usda.gov/summer/sitefinder'>www.fns.usda.gov/summer/sitefinder</a>。"
+        "p1": "要为年轻人寻找更多免费暑期餐食地点：",
+        "li1": "发送短信 “SUMMER” 至 <a href='tel:914-342-7744'>914-342-7744</a>",
+        "li2": "访问 <a target='_blank' href='https://www.fns.usda.gov/summer/sitefinder'>www.fns.usda.gov/summer/sitefinder</a>",
+        "li3": "访问 <a target='_blank' href='https://www.phila.gov/summermeals'>www.phila.gov/summermeals</a>"
       },
       "subsections": {
         "PHA": {

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -161,16 +161,15 @@ export default{
         "p1": "All students in the School District of Philadelphia receive free breakfast and lunch at school. To learn more, see the <a target='_blank' href='https://www.philasd.org/foodservices/'>district’s food services page.</a>",
         "p2": "Young people can also get snacks or meals at <a target='_blank' href='https://www.phila.gov/ost/program-locator/'>Out of School Time programs.</a>"
       },
-      "eligibility": "Children and youth age 18 or under are eligible. No ID is required.",
+      "eligibility": "All children and youth age 18 or under are eligible. No ID is required.",
       "pickupDetails": {
         "p1": "Student meal sites offer ready-to-eat meals."
       },
       "otherResources": {
-        "p1": "To find more summer meals for young people:",
-        "li1": "Call the Summer Meals Hotline at <a href='tel:215-770-4659'>(215) 770-4659</a>.",
-        "li2": "Text “FOOD” or “COMIDA” to <a href='tel:914-342-7744'>914-342-7744</a>.",
-        "li3": "Visit <a target='_blank' href='http://www.phillysummermeals.org'>www.phillysummermeals.org</a>.",
-        "li4": "Visit <a target='_blank' href='https://www.fns.usda.gov/summer/sitefinder'>www.fns.usda.gov/summer/sitefinder</a>."
+        "p1": "To find more free summer meal sites for young people:",
+        "li1": "Text: “SUMMER” to <a href='tel:914-342-7744'>914-342-7744</a>",
+        "li2": "Visit: <a target='_blank' href='https://www.fns.usda.gov/summer/sitefinder'>www.fns.usda.gov/summer/sitefinder</a>",
+        "li3": "Visit: <a target='_blank' href='https://www.phila.gov/summermeals'>www.phila.gov/summermeals</a>"
       },
       "subsections": {
         "PHA": {

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -161,16 +161,15 @@ export default{
         "p1": "Todos los estudiantes del Distrito Escolar de Filadelfia reciben desayuno y almuerzo gratis en la escuela. Para obtener más información, consulte la página de servicios de alimentación del <a target='_blank' href='https://www.philasd.org/foodservices/'>distrito.</a>",
         "p2": "Los jóvenes también pueden obtener refrigerios o comidas en los programas <a target='_blank' href='https://www.phila.gov/ost/program-locator/'>Out of School Time.</a>"
       },
-      "eligibility": "Los niños y jóvenes menores de 18 años son elegibles. No se requiere ninguna identificación.",
+      "eligibility": "Todos los niños y jóvenes menores de 18 años son elegibles. No se requiere ninguna identificación.",
       "pickupDetails": {
         "p1": "Los sitios de comidas para estudiantes ofrecen comidas listas para comer."
       },
       "otherResources": {
-        "p1": "Para encontrar más comidas de verano para jóvenes:",
-        "li1": "Llame a la línea directa de comidas de verano al <a href='tel:215-770-4659'>(215) 770-4659</a>.",
-        "li2": "Envía un mensaje de texto con la palabra «FOOD» o «COMIDA» al <a href='tel:914-342-7744'>914-342-7744</a>.",
-        "li3": "Visite <a target='_blank' href='http://www.phillysummermeals.org'>www.phillysummermeals.org</a>.",
-        "li4": "Visite <a target='_blank' href='https://www.fns.usda.gov/summer/sitefinder'>www.fns.usda.gov/summer/sitefinder</a>."
+        "p1": "Para encontrar más sitios de comidas de verano gratuitas para jóvenes:",
+        "li1": "Envía un mensaje de texto con la palabra «SUMMER» al <a href='tel:914-342-7744'>914-342-7744</a>",
+        "li2": "Visite <a target='_blank' href='https://www.fns.usda.gov/summer/sitefinder'>www.fns.usda.gov/summer/sitefinder</a>",
+        "li3": "Visite <a target='_blank' href='https://www.phila.gov/summermeals'>www.phila.gov/summermeals</a>"
       },
       "subsections": {
         "PHA": {

--- a/src/i18n/fr.js
+++ b/src/i18n/fr.js
@@ -161,16 +161,15 @@ export default{
         "p1": "Tous les élèves du district scolaire de Philadelphie bénéficient du petit déjeuner et du déjeuner gratuits à l'école. Pour en savoir plus, consultez la page des services alimentaires du <a target='_blank' href='https://www.philasd.org/foodservices/'>district.</a>",
         "p2": "Les jeunes peuvent également se procurer des collations ou des repas dans <a target='_blank' href='https://www.phila.gov/ost/program-locator/'>le cadre des programmes de temps non scolaire.</a>"
       },
-      "eligibility": "Les enfants et les jeunes âgés de 18 ans ou moins sont éligibles. Aucune pièce d'identité n'est requise.",
+      "eligibility": "Tous les enfants et les jeunes âgés de 18 ans ou moins sont éligibles. Aucune pièce d'identité n'est requise.",
       "pickupDetails": {
         "p1": "Les sites de restauration pour étudiants proposent des repas prêts à manger."
       },
       "otherResources": {
-        "p1": "Pour trouver d'autres repas d'été pour les jeunes :",
-        "li1": "Appelez la hotline des repas d'été au <a href='tel:215-770-4659'>(215) 770-4659</a>.",
-        "li2": "Envoyez « FOOD » ou « COMIDA » par SMS au <a href='tel:914-342-7744'>914-342-7744</a>.",
-        "li3": "Visitez le site <a target='_blank' href='http://www.phillysummermeals.org'>www.phillysummermeals.org</a>.",
-        "li4": "Rendez-vous sur <a target='_blank' href='https://www.fns.usda.gov/summer/sitefinder'>www.fns.usda.gov/summer/sitefinder</a>."
+        "p1": "Pour trouver d'autres sites de repas d'été gratuits pour les jeunes :",
+        "li1": "Envoyez « SUMMER » par SMS au <a href='tel:914-342-7744'>914-342-7744</a>",
+        "li2": "Rendez-vous sur <a target='_blank' href='https://www.fns.usda.gov/summer/sitefinder'>www.fns.usda.gov/summer/sitefinder</a>",
+        "li3": "Rendez-vous sur <a target='_blank' href='https://www.phila.gov/summermeals'>www.phila.gov/summermeals</a>"
       },
       "subsections": {
         "PHA": {

--- a/src/i18n/ht.js
+++ b/src/i18n/ht.js
@@ -161,16 +161,15 @@ export default{
         "p1": "Tout elèv nan Distri Lekòl la nan Philadelphia resevwa manje maten gratis ak manje midi nan lekòl la. Pou aprann plis, gade paj <a target='_blank' href='https://www.philasd.org/foodservices/'>sèvis manje distri a.</a>",
         "p2": "Jèn moun yo ka jwenn tou ti goute oswa manje nan pwogram <a target='_blank' href='https://www.phila.gov/ost/program-locator/'>Soti nan Tan Lekòl la.</a>"
       },
-      "eligibility": "Timoun ak jèn ki gen laj 18 oswa anba yo kalifye. Pa gen okenn ID obligatwa.",
+      "eligibility": "Tout timoun ak jèn ki gen laj 18 oswa anba yo kalifye. Pa gen okenn ID obligatwa.",
       "pickupDetails": {
         "p1": "Sit repa elèv yo ofri manje pare pou manje."
       },
       "otherResources": {
-        "p1": "Pou jwenn plis manje ete pou jèn moun:",
-        "li1": "Rele liy dirèk Manje pandan ete a nan <a href='tel:215-770-4659'>(215) 77</a> 0-4659.",
-        "li2": "Tèks “FOOD” oswa “COMIDA” nan <a href='tel:914-342-7744'>9</a> 14-342-7744.",
-        "li3": "Vizite <a target='_blank' href='http://www.phillysummermeals.org'>www.ph</a> illysummermeals.org.",
-        "li4": "Vizite <a target='_blank' href='https://www.fns.usda.gov/summer/sitefinder'>www.fn</a> s.usda.gov/summer/sitefinder."
+        "p1": "Pou jwenn plis sit manje ete gratis pou jèn moun:",
+        "li1": "Tèks: “SUMMER” nan <a href='tel:914-342-7744'>914-342-7744</a>",
+        "li2": "Vizite <a target='_blank' href='https://www.fns.usda.gov/summer/sitefinder'>www.fns.usda.gov/summer/sitefinder</a>",
+        "li3": "Vizite <a target='_blank' href='https://www.phila.gov/summermeals'>www.phila.gov/summermeals</a>"
       },
       "subsections": {
         "PHA": {

--- a/src/i18n/pt.js
+++ b/src/i18n/pt.js
@@ -161,16 +161,15 @@ export default{
         "p1": "Todos os alunos do Distrito Escolar da Filadélfia recebem café da manhã e almoço gratuitos na escola. Para saber mais, consulte a página de serviços de alimentação do <a target='_blank' href='https://www.philasd.org/foodservices/'>distrito.</a>",
         "p2": "Os jovens também podem comer lanches ou refeições nos programas <a target='_blank' href='https://www.phila.gov/ost/program-locator/'>Fora do Horário Escolar.</a>"
       },
-      "eligibility": "Crianças e jovens com 18 anos ou menos são elegíveis. Nenhum documento de identidade é necessário.",
+      "eligibility": "Todas as crianças e jovens com 18 anos ou menos são elegíveis. Nenhum documento de identidade é necessário.",
       "pickupDetails": {
         "p1": "Os sites de refeições para estudantes oferecem refeições prontas para comer."
       },
       "otherResources": {
-        "p1": "Para encontrar mais refeições de verão para jovens:",
-        "li1": "Ligue para a Linha Direta de Refeições de Verão em <a href='tel:215-770-4659'>(215)</a> 770-4659.",
-        "li2": "Envie “FOOD” ou “COMIDA” para <a href='tel:914-342-7744'>914-342-7744</a>.",
-        "li3": "Visite <a target='_blank' href='http://www.phillysummermeals.org'>www.phillysummermeals.org</a>.",
-        "li4": "Visite <a target='_blank' href='https://www.fns.usda.gov/summer/sitefinder'>www.fns.usda.gov/summer/sitefinder</a>."
+        "p1": "Para encontrar mais locais de refeições de verão gratuitas para jovens:",
+        "li1": "Envie “SUMMER” para <a href='tel:914-342-7744'>914-342-7744</a>",
+        "li2": "Visite <a target='_blank' href='https://www.fns.usda.gov/summer/sitefinder'>www.fns.usda.gov/summer/sitefinder</a>",
+        "li3": "Visite <a target='_blank' href='https://www.phila.gov/summermeals'>www.phila.gov/summermeals</a>"
       },
       "subsections": {
         "PHA": {

--- a/src/i18n/ru.js
+++ b/src/i18n/ru.js
@@ -161,16 +161,15 @@ export default{
         "p1": "Все учащиеся школьного округа Филадельфии получают бесплатный завтрак и обед в школе. Чтобы узнать больше, посетите страницу общественного питания <a target='_blank' href='https://www.philasd.org/foodservices/'>округа.</a>",
         "p2": "Молодые люди также могут перекусить или поесть в <a target='_blank' href='https://www.phila.gov/ost/program-locator/'>рамках программ «Вне школы».</a>"
       },
-      "eligibility": "Право на участие имеют дети и подростки в возрасте до 18 лет. Удостоверение личности не требуется.",
+      "eligibility": "Право на участие имеют все дети и подростки в возрасте до 18 лет. Удостоверение личности не требуется.",
       "pickupDetails": {
         "p1": "Сайты студенческого питания предлагают готовые к употреблению блюда."
       },
       "otherResources": {
-        "p1": "Чтобы найти больше летних блюд для молодежи:",
-        "li1": "Позвоните на горячую линию «Летнее питание» по телефону <a href='tel:215-770-4659'>(215) 770-4659</a>.",
-        "li2": "Отправьте сообщение «ЕДА» или «COMIDA» на номер <a href='tel:914-342-7744'>914-342-7744</a>.",
-        "li3": "Посетите сайт <a target='_blank' href='http://www.phillysummermeals.org'>www.phillysummermeals.org</a>.",
-        "li4": "Посетите сайт <a target='_blank' href='https://www.fns.usda.gov/summer/sitefinder'>www.fns.usda.gov/summer/sitefinder</a>."
+        "p1": "Чтобы найти больше бесплатных летних пунктов питания для молодежи:",
+        "li1": "Отправьте сообщение «SUMMER» на номер <a href='tel:914-342-7744'>914-342-7744</a>",
+        "li2": "Посетите сайт <a target='_blank' href='https://www.fns.usda.gov/summer/sitefinder'>www.fns.usda.gov/summer/sitefinder</a>",
+        "li3": "Посетите сайт <a target='_blank' href='https://www.phila.gov/summermeals'>www.phila.gov/summermeals</a>"
       },
       "subsections": {
         "PHA": {

--- a/src/i18n/vi.js
+++ b/src/i18n/vi.js
@@ -161,16 +161,15 @@ export default{
         "p1": "Tất cả học sinh ở Học khu Philadelphia đều nhận được bữa sáng và bữa trưa miễn phí tại trường. Để tìm hiểu thêm, hãy xem trang dịch vụ ăn uống của <a target='_blank' href='https://www.philasd.org/foodservices/'>quận.</a>",
         "p2": "Những người trẻ tuổi cũng có thể nhận đồ ăn nhẹ hoặc bữa ăn tại các chương trình <a target='_blank' href='https://www.phila.gov/ost/program-locator/'>Out of School Time.</a>"
       },
-      "eligibility": "Trẻ em và thanh thiếu niên từ 18 tuổi trở xuống đủ điều kiện. Không yêu cầu ID.",
+      "eligibility": "Tất cả trẻ em và thanh thiếu niên từ 18 tuổi trở xuống đều đủ điều kiện. Không yêu cầu ID.",
       "pickupDetails": {
         "p1": "Các trang web bữa ăn dành cho sinh viên cung cấp các bữa ăn sẵn."
       },
       "otherResources": {
-        "p1": "Để tìm thêm bữa ăn mùa hè cho giới trẻ:",
-        "li1": "Gọi cho Đường dây nóng Bữa ăn Mùa hè theo <a href='tel:215-770-4659'>số (215) 770-4659</a>.",
-        "li2": "Nhắn tin “THỰC PHẨM” hoặc “COMIDA” đến <a href='tel:914-342-7744'>9</a> 14-342-7744.",
-        "li3": "Truy cập <a target='_blank' href='http://www.phillysummermeals.org'>www.ph</a> illysummermeals.org.",
-        "li4": "Truy cập <a target='_blank' href='https://www.fns.usda.gov/summer/sitefinder'>www.fn</a> s.usda.gov/summer/sitefinder."
+        "p1": "Để tìm thêm địa điểm bữa ăn mùa hè miễn phí cho giới trẻ:",
+        "li1": "Nhắn tin “SUMMER” đến <a href='tel:914-342-7744'>914-342-7744</a>",
+        "li2": "Truy cập <a target='_blank' href='https://www.fns.usda.gov/summer/sitefinder'>www.fns.usda.gov/summer/sitefinder</a>",
+        "li3": "Truy cập <a target='_blank' href='https://www.phila.gov/summermeals'>www.phila.gov/summermeals</a>"
       },
       "subsections": {
         "PHA": {


### PR DESCRIPTION
Move the front-page summer switch date to 2026-06-12 so the Student meal sites section shows summer content immediately instead of waiting until 6/15.

Update the section copy across all 9 locales:
- Eligibility now reads "All children and youth age 18 or under..."
- Other resources lists Text SUMMER, fns.usda.gov/summer/sitefinder, and phila.gov/summermeals; drop the hotline and phillysummermeals.org
- Renumber otherResources keys to li1/li2/li3 and render all three