### PR TITLE
Add Caring People Alliance Summer Meal Sites subsection

### DIFF
--- a/src/components/ExpandCollapseContent.vue
+++ b/src/components/ExpandCollapseContent.vue
@@ -400,6 +400,13 @@ const makeValidUrl = (url) => {
         :pickup-details="pickupDetails"
       />
 
+      <nds-school-card
+        v-if="section === 'studentMealSites' && subsection === 'Caring People Alliance Summer Meal Sites'"
+        :item="item"
+        :exceptions-list="exceptionsList"
+        :pickup-details="pickupDetails"
+      />
+
       <ppr-school-card
         v-if="section === 'studentMealSites' && subsection === 'Other Summer Meal Sites'"
         :item="item"

--- a/src/i18n/ar.js
+++ b/src/i18n/ar.js
@@ -215,6 +215,10 @@ export default{
         "CBS Food Program Summer Meal Sites": {
           "name": "مواقع إطعام CBS Food Program للوجبات الصيفية",
           "pickupDetails": "يجب تناول وجبات الطعام في الموقع. اتصل بالموقع لمزيد من التفاصيل."
+        },
+        "Caring People Alliance Summer Meal Sites": {
+          "name": "مواقع إطعام Caring People Alliance للوجبات الصيفية",
+          "pickupDetails": "يجب تناول وجبات الطعام في الموقع. اتصل بالموقع لمزيد من التفاصيل."
         }
       }
     },

--- a/src/i18n/ch.js
+++ b/src/i18n/ch.js
@@ -215,6 +215,10 @@ export default{
         "CBS Food Program Summer Meal Sites": {
           "name": "CBS Food Program 夏季餐饮网站",
           "pickupDetails": "必须在现场用餐。请联系该网站了解更多详情。"
+        },
+        "Caring People Alliance Summer Meal Sites": {
+          "name": "Caring People Alliance 夏季餐饮网站",
+          "pickupDetails": "必须在现场用餐。请联系该网站了解更多详情。"
         }
       }
     },

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -215,6 +215,10 @@ export default{
         "CBS Food Program Summer Meal Sites": {
           "name": "CBS Food Program Summer Meal Sites",
           "pickupDetails": "Meals must be eaten on site. Contact the site for more details."
+        },
+        "Caring People Alliance Summer Meal Sites": {
+          "name": "Caring People Alliance Summer Meal Sites",
+          "pickupDetails": "Meals must be eaten on site. Contact the site for more details."
         }
       }
     },

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -215,6 +215,10 @@ export default{
         "CBS Food Program Summer Meal Sites": {
           "name": "Sitios de comidas de verano CBS Food Program",
           "pickupDetails": "Las comidas deben consumirse en el establecimiento. Comunícate con el sitio para obtener más información."
+        },
+        "Caring People Alliance Summer Meal Sites": {
+          "name": "Sitios de comidas de verano Caring People Alliance",
+          "pickupDetails": "Las comidas deben consumirse en el establecimiento. Comunícate con el sitio para obtener más información."
         }
       }
     },

--- a/src/i18n/fr.js
+++ b/src/i18n/fr.js
@@ -215,6 +215,10 @@ export default{
         "CBS Food Program Summer Meal Sites": {
           "name": "Sites de repas d'été CBS Food Program",
           "pickupDetails": "Les repas doivent être pris sur place. Contactez le site pour plus de détails."
+        },
+        "Caring People Alliance Summer Meal Sites": {
+          "name": "Sites de repas d'été Caring People Alliance",
+          "pickupDetails": "Les repas doivent être pris sur place. Contactez le site pour plus de détails."
         }
       }
     },

--- a/src/i18n/ht.js
+++ b/src/i18n/ht.js
@@ -215,6 +215,10 @@ export default{
         "CBS Food Program Summer Meal Sites": {
           "name": "CBS Food Program Ete Sit Repa",
           "pickupDetails": "Manje yo dwe manje sou sit. Kontakte sit la pou plis detay."
+        },
+        "Caring People Alliance Summer Meal Sites": {
+          "name": "Caring People Alliance Ete Sit Repa",
+          "pickupDetails": "Manje yo dwe manje sou sit. Kontakte sit la pou plis detay."
         }
       }
     },

--- a/src/i18n/pt.js
+++ b/src/i18n/pt.js
@@ -215,6 +215,10 @@ export default{
         "CBS Food Program Summer Meal Sites": {
           "name": "Sites de refeições de verão do CBS Food Program",
           "pickupDetails": "As refeições devem ser consumidas no local. Entre em contato com o site para obter mais detalhes."
+        },
+        "Caring People Alliance Summer Meal Sites": {
+          "name": "Sites de refeições de verão da Caring People Alliance",
+          "pickupDetails": "As refeições devem ser consumidas no local. Entre em contato com o site para obter mais detalhes."
         }
       }
     },

--- a/src/i18n/ru.js
+++ b/src/i18n/ru.js
@@ -215,6 +215,10 @@ export default{
         "CBS Food Program Summer Meal Sites": {
           "name": "Сайты летнего питания CBS Food Program",
           "pickupDetails": "Блюда должны быть съедены на месте. Свяжитесь с сайтом для получения более подробной информации."
+        },
+        "Caring People Alliance Summer Meal Sites": {
+          "name": "Сайты летнего питания Caring People Alliance",
+          "pickupDetails": "Блюда должны быть съедены на месте. Свяжитесь с сайтом для получения более подробной информации."
         }
       }
     },

--- a/src/i18n/vi.js
+++ b/src/i18n/vi.js
@@ -215,6 +215,10 @@ export default{
         "CBS Food Program Summer Meal Sites": {
           "name": "Trang web bữa ăn mùa hè CBS Food Program",
           "pickupDetails": "Các bữa ăn phải được ăn tại chỗ. Liên hệ với trang web để biết thêm chi tiết."
+        },
+        "Caring People Alliance Summer Meal Sites": {
+          "name": "Trang web bữa ăn mùa hè Caring People Alliance",
+          "pickupDetails": "Các bữa ăn phải được ăn tại chỗ. Liên hệ với trang web để biết thêm chi tiết."
         }
       }
     },

--- a/src/main.js
+++ b/src/main.js
@@ -491,7 +491,7 @@ let $config = {
       titleSingular: 'studentMealSite',
       color: '#721817',
       // subsections: [ 'PSD', 'PHA', 'CHARTER', 'Recreation Center', 'playstreets', 'NDS', 'Other Summer Meal Sites', 'Philabundance Summer Meal Sites', 'Caring for Friends' ],
-      subsections: [ 'PHA', 'Recreation Center', 'playstreets', 'NDS', 'Other Summer Meal Sites', 'Philabundance Summer Meal Sites', 'Caring for Friends', 'JSJ Food Bank', 'ITAVTFOC Summer Meal Sites', 'Feed Philly Now Summer Meal Sites', 'CBS Food Program Summer Meal Sites' ],
+      subsections: [ 'PHA', 'Recreation Center', 'playstreets', 'NDS', 'Other Summer Meal Sites', 'Philabundance Summer Meal Sites', 'Caring for Friends', 'JSJ Food Bank', 'ITAVTFOC Summer Meal Sites', 'Feed Philly Now Summer Meal Sites', 'CBS Food Program Summer Meal Sites', 'Caring People Alliance Summer Meal Sites' ],
       hideCounts: false,
     },
     olderAdultMealSites: {
@@ -535,6 +535,7 @@ let $config = {
     'ITAVTFOC Summer Meal Sites': 'studentMealSites',
     'Feed Philly Now Summer Meal Sites': 'studentMealSites',
     'CBS Food Program Summer Meal Sites': 'studentMealSites',
+    'Caring People Alliance Summer Meal Sites': 'studentMealSites',
     'Free Grocery Site': 'foodSites',
     'Neighborhood Community Action Center': 'publicBenefits',
     'Free Meal Site': 'generalMealSites',


### PR DESCRIPTION
Wire a new student-meal subsection mirroring the CBS Food Program pattern: add it to studentMealSites.subsections and the category lookup map in main.js, route it to nds-school-card in ExpandCollapseContent.vue, and add name + pickupDetails to all 9 locales. Uses the shared student-meal eligibility; pickupDetails reuses the existing CBS translation.

Inert until ArcGIS data loads sites with
category = "Caring People Alliance Summer Meal Sites".